### PR TITLE
fix: Return correct variable on zephyr robot lib

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/robot_framework/ZephyrLibrary.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/robot_framework/ZephyrLibrary.py
@@ -37,7 +37,7 @@ class ZephyrLibrary:
         if self.device is None:
             device_object = DeviceFactory.get_device_object(self.twister_harness_config)
             self.device = device_object
-        return device_object
+        return self.device
 
     def run_device(self):
         if self.device is None:


### PR DESCRIPTION
We accidentally returned the local variable instead of the initialized instance variable. This change fixes it.