### PR TITLE
feat: Add device properties to twister execution

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/argument_handler.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/argument_handler.py
@@ -50,6 +50,12 @@ class ArgumentHandler:
             help="Serial device baud rate (default 115200).",
         )
         self.argument_add_func(
+            "--device-properties",
+            nargs="*",
+            help="Properties of the connected hardware device",
+            default=[],
+        )
+        self.argument_add_func(
             "--runner", help="Use the specified west runner (pyocd, nrfjprog, etc.)."
         )
         self.argument_add_func(

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -33,7 +33,6 @@ def device_object(twister_harness_config: TwisterHarnessConfig) -> Generator[Dev
     finally:  # to make sure we close all running processes execution
         device_object.close()
 
-
 def determine_scope(fixture_name, config):
     if dut_scope := config.getoption("--dut-scope", None):
         return dut_scope

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -18,6 +18,7 @@ class DeviceConfig:
     build_dir: Path
     base_timeout: float = 60.0  # [s]
     platform: str = ''
+    properties: list[str] = field(default_factory=list, repr=False)
     serial: str = ''
     baud: int = 115200
     runner: str = ''
@@ -50,6 +51,7 @@ class TwisterHarnessConfig:
             build_dir=_cast_to_path(options.build_dir),
             base_timeout=options.base_timeout,
             platform=options.platform,
+            properties=options.device_properties,
             serial=options.device_serial,
             baud=options.device_serial_baud,
             runner=options.runner,

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -49,7 +49,9 @@ class DUT(object):
                  post_flash_script=None,
                  runner=None,
                  flash_timeout=60,
-                 flash_with_test=False):
+                 flash_with_test=False,
+                 properties=None,
+                 ):
 
         self.serial = serial
         self.baud = serial_baud or 115200
@@ -73,6 +75,7 @@ class DUT(object):
         self.match = False
         self.flash_timeout = flash_timeout
         self.flash_with_test = flash_with_test
+        self.properties = properties
 
     @property
     def available(self):
@@ -238,6 +241,7 @@ class HardwareMap:
             baud = dut.get('baud', None)
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
+            properties = dut.get('properties', [])
             connected= dut.get('connected') and ((serial or serial_pty) is not None)
             if not connected:
                 continue
@@ -254,7 +258,9 @@ class HardwareMap:
                           post_script=post_script,
                           post_flash_script=post_flash_script,
                           flash_timeout=flash_timeout,
-                          flash_with_test=flash_with_test)
+                          flash_with_test=flash_with_test,
+                          properties=properties,
+                          )
             new_dut.fixtures = fixtures
             new_dut.counter = 0
             self.duts.append(new_dut)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -373,6 +373,9 @@ class TwisterLibraryHarness(Harness, abc.ABC):
         if hardware.product:
             command.append(f'--device-product={hardware.product}')
 
+        if hardware.properties:
+            command.extend(['--device-properties', *hardware.properties])
+
         if hardware.pre_script:
             command.append(f'--pre-script={hardware.pre_script}')
 

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -61,3 +61,8 @@ sequence:
       "flash_with_test":
         type: bool
         required: false
+      "properties":
+        type: seq
+        required: false
+        sequence:
+          - type: str


### PR DESCRIPTION
Until now, there is no way to give additional information of the device that is not restricting the execution to twister and the runners.

With adding a device properties list, we can pass things like connection information, which afterwards can be used in pytest and robotframework.