### PR TITLE
Add Native SIM Socket virtual can 

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -487,9 +487,13 @@ The following peripherals are currently provided with this board:
     :ref:`its section <nsim_per_disp_sdl>`.
 
 **CAN controller**
-  It is possible to use a host CAN controller with the native SockerCAN Linux driver. It can be
+  It is possible to use a host CAN controller with the native SocketCAN Linux driver. It can be
   enabled with :kconfig:option:`CONFIG_CAN_NATIVE_LINUX` and configured with the device tree binding
   :dtcompatible:`zephyr,native-linux-can`.
+
+  It is possible to specify which CAN interface will be used by the app using the ``--can-if``
+  command-line option. This option overrides **every** Linux SocketCAN driver instance to use the specified
+  interface.
 
 .. _native_ptty_uart:
 

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -9,6 +9,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <cmdline.h>
+#include <posix_native_task.h>
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/kernel.h>
@@ -45,6 +47,8 @@ struct can_native_linux_config {
 	const struct can_driver_config common;
 	const char *if_name;
 };
+
+static const char *if_name_cmd_opt;
 
 static void dispatch_frame(const struct device *dev, struct can_frame *frame)
 {
@@ -465,13 +469,21 @@ static int can_native_linux_init(const struct device *dev)
 {
 	const struct can_native_linux_config *cfg = dev->config;
 	struct can_native_linux_data *data = dev->data;
+	const char *if_name;
 
 	k_mutex_init(&data->filter_mutex);
 	k_sem_init(&data->tx_idle, 1, 1);
 
-	data->dev_fd = linux_socketcan_iface_open(cfg->if_name);
+	if (if_name_cmd_opt != NULL) {
+		if_name = if_name_cmd_opt;
+	} else {
+		if_name = cfg->if_name;
+	}
+
+	LOG_DBG("Opening %s", if_name);
+	data->dev_fd = linux_socketcan_iface_open(if_name);
 	if (data->dev_fd < 0) {
-		LOG_ERR("Cannot open %s (%d)", cfg->if_name, data->dev_fd);
+		LOG_ERR("Cannot open %s (%d)", if_name, data->dev_fd);
 		return -ENODEV;
 	}
 
@@ -502,3 +514,22 @@ CAN_DEVICE_DT_INST_DEFINE(inst, can_native_linux_init, NULL,			\
 			  &can_native_linux_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_NATIVE_LINUX_INIT)
+
+static void add_native_posix_options(void)
+{
+	static struct args_struct_t can_native_posix_options[] = {
+		{
+			.is_mandatory = false,
+			.option = "can-if",
+			.name = "name",
+			.type = 's',
+			.dest = (void *)&if_name_cmd_opt,
+			.descript = "Name of the host CAN interface to use",
+		},
+		ARG_TABLE_ENDMARKER,
+	};
+
+	native_add_command_line_opts(can_native_posix_options);
+}
+
+NATIVE_TASK(add_native_posix_options, PRE_BOOT_1, 10);

--- a/dts/bindings/can/zephyr,native-linux-can.yaml
+++ b/dts/bindings/can/zephyr,native-linux-can.yaml
@@ -11,4 +11,7 @@ properties:
   host-interface:
     type: string
     required: true
-    description: Linux host interface name (e.g. zcan0, vcan0, can0, ...)
+    description: |
+      Linux host interface name (e.g. zcan0, vcan0, can0, ...).
+      This property can be overridden using the --can-if command-line
+      option. Note that it applies for every instance of this driver.

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -118,7 +118,22 @@ class NativeSimulatorAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [str(self.device_config.build_dir / 'zephyr' / 'zephyr.exe')]
+        base_command = [str(self.device_config.build_dir / 'zephyr' / 'zephyr.exe')]
+        cli_flags = self._get_execution_cli_flags()
+        self.command = base_command + cli_flags
+
+    def _get_execution_cli_flags(self) -> list[str]:
+        """Add additional flags for execution"""
+        return [f'--can-if={self._extract_can()}']
+
+    def _extract_can(self) -> str:
+        device_properties = self.device_config.properties
+        for property in device_properties:
+            key, value = property.split(":")
+            if key == 'host_can':
+                return value
+
+        return 'vcan0'
 
 
 class UnitSimulatorAdapter(BinaryAdapterBase):


### PR DESCRIPTION
This PR adds capabilities to search and use virtual CAN devices in
different native_sim test executions. Hereby, each execution gets its
own virtual can device so no interference happens. If no vcan is found,
it uses the one from device tree, but prints a warning before.

This is not the cleanest solution, but works in our tests and fixes
scaling problem for protocol tests without hardware