### PR TITLE
fixup: count vcans as 'qsize' throws NotImplemented

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -32,12 +32,13 @@ _WINDOWS = platform.system() == 'Windows'
 # this is done globally, so each process later has access to the
 # same instance. This can and should be refactored for 'upstream' (if wanted)
 vcan_queue = mp.Queue()
+initial_number_of_vcans = 0
 for i in itertools.count():
     if not os.path.exists(f"/sys/class/net/vcan{i}"):
         break
     vcan_queue.put(f"vcan{i}")
+    initial_number_of_vcans += 1
 
-initial_number_of_vcans = vcan_queue.qsize()
 if initial_number_of_vcans == 0:
     logger.warning("No virtual CAN in form `vcan$i` found! "
                    "If you execute tests with 'CAN' on native_sim, "


### PR DESCRIPTION
It seems like on some systems (like MacOS), qsize throws an exception 'NotImplementedError' due to a broken sem_getvalue implementation. Therefore, we manually count the number of vcans.