### PR TITLE
fix(can_fake): correct preprocessor directive of msgq injection

### DIFF
--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -23,9 +23,8 @@ struct fake_can_data {
 	struct can_driver_data common;
 #ifdef CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
 	struct k_msgq *rx_msgq; /* Receiver side message queue added via can_add_rx_filter */
-#endif /* CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION */	
+#endif                          /* CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION */
 };
-
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_start, const struct device *);
 
@@ -136,49 +135,40 @@ static const struct can_driver_api fake_can_driver_api = {
 	.set_state_change_callback = fake_can_set_state_change_callback,
 	.get_core_clock = fake_can_get_core_clock,
 	.get_max_filters = fake_can_get_max_filters,
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x01,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x0f,
-		.prop_seg = 0x0f,
-		.phase_seg1 = 0x0f,
-		.phase_seg2 = 0x0f,
-		.prescaler = 0xffff
-	},
+	.timing_min = {.sjw = 0x01,
+		       .prop_seg = 0x01,
+		       .phase_seg1 = 0x01,
+		       .phase_seg2 = 0x01,
+		       .prescaler = 0x01},
+	.timing_max = {.sjw = 0x0f,
+		       .prop_seg = 0x0f,
+		       .phase_seg1 = 0x0f,
+		       .phase_seg2 = 0x0f,
+		       .prescaler = 0xffff},
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = fake_can_set_timing_data,
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x01,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x0f,
-		.prop_seg = 0x0f,
-		.phase_seg1 = 0x0f,
-		.phase_seg2 = 0x0f,
-		.prescaler = 0xffff
-	},
+	.timing_data_min = {.sjw = 0x01,
+			    .prop_seg = 0x01,
+			    .phase_seg1 = 0x01,
+			    .phase_seg2 = 0x01,
+			    .prescaler = 0x01},
+	.timing_data_max = {.sjw = 0x0f,
+			    .prop_seg = 0x0f,
+			    .phase_seg1 = 0x0f,
+			    .phase_seg2 = 0x0f,
+			    .prescaler = 0xffff},
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
-#define FAKE_CAN_INIT(inst)						     \
-	static const struct fake_can_config fake_can_config_##inst = {	     \
-		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0U),	     \
-	};								     \
-									     \
-	static struct fake_can_data fake_can_data_##inst;		     \
-									     \
-	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &fake_can_data_##inst,   \
-				  &fake_can_config_##inst, POST_KERNEL,	     \
-				  CONFIG_CAN_INIT_PRIORITY,                  \
+#define FAKE_CAN_INIT(inst)                                                                        \
+	static const struct fake_can_config fake_can_config_##inst = {                             \
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0U),                                 \
+	};                                                                                         \
+                                                                                                   \
+	static struct fake_can_data fake_can_data_##inst;                                          \
+                                                                                                   \
+	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &fake_can_data_##inst,                         \
+				  &fake_can_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,  \
 				  &fake_can_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FAKE_CAN_INIT)

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -102,7 +102,7 @@ static void fake_can_reset_rule_before(const struct ztest_unit_test *test, void 
 	RESET_FAKE(fake_can_set_timing);
 	RESET_FAKE(fake_can_set_timing_data);
 	RESET_FAKE(fake_can_send);
-#if CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
+#ifndef CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
 	/* When this config is enabled, a custom function is used. */
 	RESET_FAKE(fake_can_add_rx_filter);
 #endif /* CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION */

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -21,7 +21,7 @@ struct fake_can_config {
 
 struct fake_can_data {
 	struct can_driver_data common;
-#if CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
+#ifdef CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
 	struct k_msgq *rx_msgq; /* Receiver side message queue added via can_add_rx_filter */
 #endif /* CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION */	
 };
@@ -66,7 +66,7 @@ static int fake_can_get_core_clock_delegate(const struct device *dev, uint32_t *
 	return 0;
 }
 
-#if CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
+#ifdef CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
 int fake_can_add_rx_filter(const struct device *dev, can_rx_callback_t callback, void *user_data,
 			   const struct can_filter *filter)
 {

--- a/include/zephyr/drivers/can/can_fake.h
+++ b/include/zephyr/drivers/can/can_fake.h
@@ -47,7 +47,7 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bo
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_core_clock, const struct device *, uint32_t *);
 
-#if CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
+#ifdef CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION
 int inject_can_frame_to_recv_msgq(const struct device *dev, const struct can_frame *frame);
 #endif /* CONFIG_CAN_FAKE_ENABLE_RX_MESSAGE_QUEUE_INJECTION */
 


### PR DESCRIPTION
* Correct preprocessor directive of message queue injection.
* Apply clang-format style.
* Prefer `#ifdef`/`#ifndef` over `#if`.