### PR TITLE
feat: drivers: tcs3430: add ATIME and AGAIN configs

### DIFF
--- a/dts/bindings/sensor/ams,tcs3430.yaml
+++ b/dts/bindings/sensor/ams,tcs3430.yaml
@@ -13,3 +13,18 @@ properties:
     required: true
     description: |
       INT pin GPIO identifier, open-drain, active low.
+  integration-cycles:
+    type: int
+    default: 256
+    description: |
+      Initial ADC integration cycle setting from 1 to 256.
+      1 cycle = 2.78ms.
+  gain:
+    type: int
+    default: 0
+    description: |
+      ALS Gain Control:
+      0 - 1x
+      1 - 4x
+      2 - 16x
+      3 - 64x

--- a/include/zephyr/drivers/sensor/tcs3430.h
+++ b/include/zephyr/drivers/sensor/tcs3430.h
@@ -12,6 +12,8 @@
 enum sensor_attribute_tcs3430 {
 	/** XYZB Integration Cycles */
 	SENSOR_ATTR_TCS3430_INTEGRATION_CYCLES = SENSOR_ATTR_PRIV_START,
+	/** Gain setting */
+	SENSOR_ATTR_TCS3430_GAIN,
 };
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TCS3430_H_ */


### PR DESCRIPTION
Adds DTS properties and driver code to set
integration time and gain for TCS3430.